### PR TITLE
Show a ChildWindow and get a result...

### DIFF
--- a/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow.Demo/CoolChildWindow.xaml
+++ b/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow.Demo/CoolChildWindow.xaml
@@ -29,6 +29,7 @@
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<TextBlock Grid.Row="0"
@@ -37,13 +38,21 @@
 		           FontWeight="Thin"
 		           Text="Yepp, it works!" />
 		<TextBox Grid.Row="1" Margin="5" />
-		<Button Grid.Row="2"
-		        Margin="5"
-		        VerticalAlignment="Bottom"
-		        Click="CloseSec_OnClick"
-		        Content="Close Me"
-		        FontSize="20"
-		        FontWeight="Thin"
-		        IsDefault="True" />
+		<UniformGrid Grid.Row="3"
+		             Margin="5"
+		             Columns="2">
+			<Button Margin="5"
+			        Click="OkButtonOnClick"
+			        Content="Ok"
+			        FontSize="20"
+			        FontWeight="Thin"
+			        IsDefault="True" />
+			<Button Margin="5"
+					Click="CloseSec_OnClick"
+			        Content="Cancel"
+			        FontSize="20"
+			        FontWeight="Thin"
+			        IsDefault="True" />
+		</UniformGrid>
 	</Grid>
 </simpleChildWindow:ChildWindow>

--- a/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow.Demo/CoolChildWindow.xaml.cs
+++ b/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow.Demo/CoolChildWindow.xaml.cs
@@ -13,9 +13,14 @@ namespace MahApps.Metro.SimpleChildWindow.Demo
 			this.InitializeComponent();
 		}
 
+		private void OkButtonOnClick(object sender, RoutedEventArgs e)
+		{
+			this.Close(true);
+		}
+
 		private void CloseSec_OnClick(object sender, RoutedEventArgs e)
 		{
-			this.Close();
+			this.Close(false);
 		}
 	}
 }

--- a/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow.Demo/MainWindow.xaml.cs
+++ b/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow.Demo/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Windows;
 using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
 
 namespace MahApps.Metro.SimpleChildWindow.Demo
 {
@@ -26,7 +27,15 @@ namespace MahApps.Metro.SimpleChildWindow.Demo
 
 		private async void ThirdTest_OnClick(object sender, RoutedEventArgs e)
 		{
-			await this.ShowChildWindowAsync(new CoolChildWindow() {IsModal = false, AllowMove = true});
+			var result = await this.ShowChildWindowAsync<bool>(new CoolChildWindow() {IsModal = false, AllowMove = true});
+			if (result)
+			{
+				await this.ShowMessageAsync("ChildWindow Result", "He, you just clicked the 'Ok' button.");
+			}
+			else
+			{
+				await this.ShowMessageAsync("ChildWindow Result", "The dialog was canceled.");
+			}
 		}
 
 		private void CloseFirst_OnClick(object sender, RoutedEventArgs e)

--- a/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow/ChildWindow.cs
+++ b/MahApps.Metro.SimpleChildWindow/MahApps.Metro.SimpleChildWindow/ChildWindow.cs
@@ -664,7 +664,7 @@ namespace MahApps.Metro.SimpleChildWindow
 					}
 					else
 					{
-						childWindow.Hide();
+						childWindow.OnClosingFinished();
 					}
 				}
 
@@ -701,10 +701,10 @@ namespace MahApps.Metro.SimpleChildWindow
 		private void HideStoryboard_Completed(object sender, EventArgs e)
 		{
 			this.hideStoryboard.Completed -= this.HideStoryboard_Completed;
-			this.Hide();
+			this.OnClosingFinished();
 		}
 
-		private void Hide()
+		private void OnClosingFinished()
 		{
 			this.RaiseEvent(new RoutedEventArgs(ClosingFinishedEvent, this));
 		}
@@ -804,6 +804,11 @@ namespace MahApps.Metro.SimpleChildWindow
 			get { return (bool)this.GetValue(IsWindowHostActiveProperty); }
 			set { this.SetValue(IsWindowHostActiveProperty, value); }
 		}
+
+		/// <summary>
+		/// Gets the child window result when the dialog will be closed.
+		/// </summary>
+		public object ChildWindowResult { get; protected set; }
 
 		DispatcherTimer autoCloseTimer;
 
@@ -1077,7 +1082,7 @@ namespace MahApps.Metro.SimpleChildWindow
 		/// <summary>
 		/// Closes this instance.
 		/// </summary>
-		public bool Close()
+		public bool Close(object childWindowResult = null)
 		{
 			// check if we really want close the dialog
 			var e = new CancelEventArgs();
@@ -1097,6 +1102,7 @@ namespace MahApps.Metro.SimpleChildWindow
 					this.CloseButtonCommandParameter = null;
 				}
 
+				this.ChildWindowResult = childWindowResult;
 				this.IsOpen = false;
 				return true;
 			}


### PR DESCRIPTION
- add a new `ChildWindowResult` property which will be set at the Close method
- override `ShowChildWindowAsync` methods to get a result

Closes #4 A DialogResult would be better
Closes #40 await ChildWindowAsync does not block main thread

Sample
```csharp
public partial class CoolChildWindow : ChildWindow
{
	public CoolChildWindow()
	{
		this.InitializeComponent();
	}

	private void OkButtonOnClick(object sender, RoutedEventArgs e)
	{
		this.Close(true);
	}

	private void CloseSec_OnClick(object sender, RoutedEventArgs e)
	{
		this.Close(false);
	}
}
```
```csharp
private async void ThirdTest_OnClick(object sender, RoutedEventArgs e)
{
	var result = await this.ShowChildWindowAsync<bool>(new CoolChildWindow() {IsModal = false, AllowMove = true});
	if (result)
	{
		await this.ShowMessageAsync("ChildWindow Result", "He, you just clicked the 'Ok' button.");
	}
	else
	{
		await this.ShowMessageAsync("ChildWindow Result", "The dialog was canceled.");
	}
}
```

![childwindow_result](https://user-images.githubusercontent.com/658431/28239757-50a38552-6973-11e7-8fab-7538bdecdec2.gif)
