### PR TITLE
(GH-74) Fix ChildWindow moving issue

### DIFF
--- a/src/MahApps.Metro.SimpleChildWindow.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.SimpleChildWindow.Demo/MainWindow.xaml.cs
@@ -50,7 +50,7 @@ namespace MahApps.Metro.SimpleChildWindow.Demo
 
 		private async void MovingTest_OnClick(object sender, RoutedEventArgs e)
 		{
-			await this.ShowChildWindowAsync(new CoolChildWindow() {IsModal = true, AllowMove = true}, RootGrid);
+			await this.ShowChildWindowAsync(new CoolChildWindow() {IsModal = true, AllowMove = true, VerticalContentAlignment = VerticalAlignment.Bottom}, RootGrid);
 		}
 	}
 }

--- a/src/MahApps.Metro.SimpleChildWindow/ChildWindow.cs
+++ b/src/MahApps.Metro.SimpleChildWindow/ChildWindow.cs
@@ -1044,8 +1044,9 @@ namespace MahApps.Metro.SimpleChildWindow
             var width = this.partOverlay.RenderSize.Width;
             var height = this.partOverlay.RenderSize.Height;
 
-            var widthOffset = width / 2 - this.partWindow.RenderSize.Width / 2;
-            var heightOffset = height / 2 - this.partWindow.RenderSize.Height / 2;
+            var offset = VisualTreeHelper.GetOffset(this.partWindow);
+            var widthOffset = offset.X;
+            var heightOffset = offset.Y;
 
             var realX = this.moveTransform.X + x + widthOffset;
             var realY = this.moveTransform.Y + y + heightOffset;


### PR DESCRIPTION
When VerticalContentAlignment is set to Bottom and AllowMove to true then the ChildWindow can be moved only to the maximum half of parent.

Use now VisualTreeHelper.GetOffset to fix this.

Closes #74 
