### PR TITLE
(GH-84) Introduce new ClosedBy property with a close reason enumeration

### DIFF
--- a/src/MahApps.Metro.SimpleChildWindow.Demo/App.xaml.cs
+++ b/src/MahApps.Metro.SimpleChildWindow.Demo/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 
 namespace MahApps.Metro.SimpleChildWindow.Demo
 {

--- a/src/MahApps.Metro.SimpleChildWindow.Demo/CoolChildWindow.xaml.cs
+++ b/src/MahApps.Metro.SimpleChildWindow.Demo/CoolChildWindow.xaml.cs
@@ -1,26 +1,25 @@
 ﻿using System.Windows;
-using MahApps.Metro.Controls;
 
 namespace MahApps.Metro.SimpleChildWindow.Demo
 {
-	/// <summary>
-	/// Interaction logic for CoolChildWindow.xaml
-	/// </summary>
-	public partial class CoolChildWindow : ChildWindow
-	{
-		public CoolChildWindow()
-		{
-			this.InitializeComponent();
-		}
+    /// <summary>
+    /// Interaction logic for CoolChildWindow.xaml
+    /// </summary>
+    public partial class CoolChildWindow : ChildWindow
+    {
+        public CoolChildWindow()
+        {
+            this.InitializeComponent();
+        }
 
-		private void OkButtonOnClick(object sender, RoutedEventArgs e)
-		{
-			this.Close(true);
-		}
+        private void OkButtonOnClick(object sender, RoutedEventArgs e)
+        {
+            this.Close(CloseReason.Ok, true);
+        }
 
-		private void CloseSec_OnClick(object sender, RoutedEventArgs e)
-		{
-			this.Close(false);
-		}
-	}
+        private void CloseSec_OnClick(object sender, RoutedEventArgs e)
+        {
+            this.Close(CloseReason.Cancel, false);
+        }
+    }
 }

--- a/src/MahApps.Metro.SimpleChildWindow.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.SimpleChildWindow.Demo/MainWindow.xaml.cs
@@ -49,8 +49,13 @@ namespace MahApps.Metro.SimpleChildWindow.Demo
 		}
 
 		private async void MovingTest_OnClick(object sender, RoutedEventArgs e)
-		{
-			await this.ShowChildWindowAsync(new CoolChildWindow() {IsModal = true, AllowMove = true, VerticalContentAlignment = VerticalAlignment.Bottom}, RootGrid);
-		}
+        {
+            var childWindow = new CoolChildWindow() {IsModal = true, AllowMove = true, VerticalContentAlignment = VerticalAlignment.Bottom};
+            var result = await this.ShowChildWindowAsync<CloseReason>(childWindow, RootGrid);
+            if (result == CloseReason.Cancel)
+            {
+                await this.ShowMessageAsync("ChildWindow Result", "The dialog was canceled.");
+            }
+        }
 	}
 }

--- a/src/MahApps.Metro.SimpleChildWindow.Demo/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro.SimpleChildWindow.Demo/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Windows;
 
 [assembly: ComVisible(false)]

--- a/src/MahApps.Metro.SimpleChildWindow/ChildWindow.cs
+++ b/src/MahApps.Metro.SimpleChildWindow/ChildWindow.cs
@@ -766,6 +766,11 @@ namespace MahApps.Metro.SimpleChildWindow
         /// </summary>
         public object ChildWindowResult { get; protected set; }
 
+        /// <summary>
+        /// Gets the dialog close reason.
+        /// </summary>
+        public CloseReason ClosedBy { get; private set; } = CloseReason.None;
+
         DispatcherTimer autoCloseTimer;
 
         private static void OnIsAutoCloseEnabledChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
@@ -828,7 +833,7 @@ namespace MahApps.Metro.SimpleChildWindow
             // if the ChildWindow is open and autoclose is still enabled then close the ChildWindow
             if (this.IsOpen && this.IsAutoCloseEnabled)
             {
-                this.Close();
+                this.Close(CloseReason.AutoClose);
             }
         }
 
@@ -958,7 +963,7 @@ namespace MahApps.Metro.SimpleChildWindow
         {
             if (Equals(e.OriginalSource, this.partOverlay) && this.CloseOnOverlay)
             {
-                this.Close();
+                this.Close(CloseReason.Overlay);
             }
         }
 
@@ -1026,7 +1031,7 @@ namespace MahApps.Metro.SimpleChildWindow
 
         private void OnCloseButtonClick(object sender, RoutedEventArgs e)
         {
-            this.Close();
+            this.Close(CloseReason.Close);
         }
 
         /// <summary>
@@ -1039,13 +1044,27 @@ namespace MahApps.Metro.SimpleChildWindow
         }
 
         /// <summary>
-        /// Closes this instance.
+        /// Closes this dialog.
         /// </summary>
+        /// <param name="childWindowResult">A dialog result (optional).</param>
         public bool Close(object childWindowResult = null)
         {
+            return this.Close(CloseReason.Close, childWindowResult);
+        }
+
+        /// <summary>
+        /// Closes this dialog.
+        /// </summary>
+        /// <param name="closedBy">The dialog close reason.</param>
+        /// <param name="childWindowResult">A dialog result (optional).</param>
+        public bool Close(CloseReason closedBy, object childWindowResult = null)
+        {
+            this.ClosedBy = closedBy;
+
             // check if we really want close the dialog
             var e = new CancelEventArgs();
             this.OnClosing(e);
+
             if (!e.Cancel)
             {
                 // now handle the command
@@ -1066,6 +1085,7 @@ namespace MahApps.Metro.SimpleChildWindow
             }
             else
             {
+                this.ClosedBy = CloseReason.None;
                 return false;
             }
         }
@@ -1075,7 +1095,7 @@ namespace MahApps.Metro.SimpleChildWindow
         {
             if (this.CloseByEscape && e.Key == Key.Escape)
             {
-                e.Handled = this.Close();
+                e.Handled = this.Close(CloseReason.Escape);
             }
 
             this.OnPreviewKeyUp(e);

--- a/src/MahApps.Metro.SimpleChildWindow/ChildWindowManager.cs
+++ b/src/MahApps.Metro.SimpleChildWindow/ChildWindowManager.cs
@@ -161,7 +161,7 @@ namespace MahApps.Metro.SimpleChildWindow
                 dialog.ClosingFinished -= OnDialogClosingFinished;
                 dialog.PreviewMouseDown -= OnDialogPreviewMouseDown;
                 container.Children.Remove(dialog);
-                tcs.TrySetResult(dialog.ChildWindowResult is TResult result ? result : default(TResult));
+                tcs.TrySetResult(dialog.ChildWindowResult is TResult result ? result : (dialog.ClosedBy is TResult closedBy ? closedBy : default));
             }
 
             dialog.ClosingFinished += OnDialogClosingFinished;

--- a/src/MahApps.Metro.SimpleChildWindow/CloseReason.cs
+++ b/src/MahApps.Metro.SimpleChildWindow/CloseReason.cs
@@ -1,0 +1,38 @@
+﻿namespace MahApps.Metro.SimpleChildWindow
+{
+    /// <summary>
+    /// ChildWindow close reasons.
+    /// </summary>
+    public enum CloseReason
+    {
+        None,
+        /// <summary>
+        /// The dialog was closed automatically.
+        /// </summary>
+        AutoClose,
+        /// <summary>
+        /// The Dialog was closed by hitting the overlay.
+        /// </summary>
+        Overlay,
+        /// <summary>
+        /// The Dialog was closed by e.g. an Ok button (optional, can be used when it's necessary).
+        /// </summary>
+        Ok,
+        /// <summary>
+        /// The Dialog was closed by e.g. an Apply button (optional, can be used when it's necessary).
+        /// </summary>
+        Apply,
+        /// <summary>
+        /// The Dialog was closed by e.g. a Cancel button (optional, can be used when it's necessary).
+        /// </summary>
+        Cancel,
+        /// <summary>
+        /// The Dialog was closed by the Close method or the Close button on the title bar.
+        /// </summary>
+        Close,
+        /// <summary>
+        /// The Dialog was closed by the Escape key.
+        /// </summary>
+        Escape
+    }
+}


### PR DESCRIPTION
The new property `ClosedBy` indicates now which close reason occured.

```csharp
var childWindow = new CoolChildWindow() { IsModal = true, AllowMove = true, VerticalContentAlignment = VerticalAlignment.Bottom };
await this.ShowChildWindowAsync<CloseReason>(childWindow, RootGrid);
if (childWindow.ClosedBy == CloseReason.Cancel)
{
    await this.ShowMessageAsync("ChildWindow Result", "The dialog was canceled.");
}
```

It's also possible to grab this directly as the result of the ShowMessageAsync method.

```csharp
var childWindow = new CoolChildWindow() {IsModal = true, AllowMove = true, VerticalContentAlignment = VerticalAlignment.Bottom};
var result = await this.ShowChildWindowAsync<CloseReason>(childWindow, RootGrid);
if (result == CloseReason.Cancel)
{
    await this.ShowMessageAsync("ChildWindow Result", "The dialog was canceled.");
}
```

Closes #84 
Closes #91 
